### PR TITLE
Add dylibbundler to the list of macOS deps

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -64,7 +64,7 @@ just like for the Linux version.
 2. Install the dependencies:
 
     ```
-    brew install sdl2 sdl2_image
+    brew install sdl2 sdl2_image dylibbundler
     ```
 
 ### Building


### PR DESCRIPTION
Once I installed `dylibbundler` with `brew` the build worked and I could play Brogue + Houserules 🎉 